### PR TITLE
Fixes issue #220 was missing ipv6 lines

### DIFF
--- a/bin/postgresql11.17/pg_hba.conf.ber
+++ b/bin/postgresql11.17/pg_hba.conf.ber
@@ -1,2 +1,3 @@
 # TYPE      DATABASE        USER            ADDRESS                 METHOD
-host        all             all             127.0.0.1/32            trust
+  host        all           all             127.0.0.1/32            trust
+  host 		    all           all              ::1/128	      				trust

--- a/bin/postgresql11.3/pg_hba.conf.ber
+++ b/bin/postgresql11.3/pg_hba.conf.ber
@@ -1,2 +1,3 @@
 # TYPE      DATABASE        USER            ADDRESS                 METHOD
-host        all             all             127.0.0.1/32            trust
+  host        all           all             127.0.0.1/32            trust
+  host 		    all           all              ::1/128	      				trust

--- a/bin/postgresql12.12/pg_hba.conf.ber
+++ b/bin/postgresql12.12/pg_hba.conf.ber
@@ -1,2 +1,3 @@
 # TYPE      DATABASE        USER            ADDRESS                 METHOD
-host        all             all             127.0.0.1/32            trust
+  host        all           all             127.0.0.1/32            trust
+  host 		    all           all              ::1/128	      				trust

--- a/bin/postgresql13.7/pg_hba.conf.ber
+++ b/bin/postgresql13.7/pg_hba.conf.ber
@@ -1,2 +1,3 @@
 # TYPE      DATABASE        USER            ADDRESS                 METHOD
-host        all             all             127.0.0.1/32            trust
+  host        all           all             127.0.0.1/32            trust
+  host 		    all           all              ::1/128	      				trust

--- a/bin/postgresql13.8/pg_hba.conf.ber
+++ b/bin/postgresql13.8/pg_hba.conf.ber
@@ -1,2 +1,3 @@
 # TYPE      DATABASE        USER            ADDRESS                 METHOD
-host        all             all             127.0.0.1/32            trust
+  host        all           all             127.0.0.1/32            trust
+  host 		    all           all              ::1/128	      				trust

--- a/bin/postgresql14.4/pg_hba.conf.ber
+++ b/bin/postgresql14.4/pg_hba.conf.ber
@@ -1,2 +1,3 @@
 # TYPE      DATABASE        USER            ADDRESS                 METHOD
-host        all             all             127.0.0.1/32            trust
+  host        all           all             127.0.0.1/32            trust
+  host 		    all           all              ::1/128	      				trust

--- a/bin/postgresql14.5/pg_hba.conf.ber
+++ b/bin/postgresql14.5/pg_hba.conf.ber
@@ -1,2 +1,3 @@
 # TYPE      DATABASE        USER            ADDRESS                 METHOD
-host        all             all             127.0.0.1/32            trust
+  host        all           all             127.0.0.1/32            trust
+  host 		    all           all              ::1/128	      				trust

--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 bundle.name = postgresql
-bundle.release = 2022.08.28
+bundle.release = 2022.09.13
 bundle.type = bins
 bundle.format = 7z
 


### PR DESCRIPTION
When installing Joomla with postgres your unable to due to ipv6 missing.  idky it matters but it did.
to test:
* clone the latest -dev of joomla.
* attempt to install joomla using postgres it will fail during db phase
* replace all postgres versions
* remove /bin/postgres/current folder
* do reload
* attempt to install joomla again.  Postgress will install

once merged:
release hotfix pre-release https://github.com/Bearsampp/module-postgresql/releases/tag/2022.09.13
replace table and all rows in postgres module article.
if desired make hotfix announcement in discussion and a new "news" article of that release as always with anouncements.

