### PR TITLE
Update releases.properties from release 2026.6.2

### DIFF
--- a/releases.properties
+++ b/releases.properties
@@ -1,5 +1,7 @@
+18.4 = https://github.com/Bearsampp/module-postgresql/releases/download/2026.6.2/bearsampp-postgresql-18.4-2025.6.2.7z
 18.3 = https://github.com/Bearsampp/module-postgresql/releases/download/2026.3.8/bearsampp-postgresql-18.3-2025.3.8.7z
-18.1 = https://github.com/Bearsampp/module-postgresql/releases/download/2025.11.22/bearsampp-postgresql-18.1-2025.7.2.7z
+18.1 = https://github.com/Bearsampp/module-postgresql/releases/download/2026.6.2/bearsampp-postgresql-18.1-2025.6.2.7z
+17.10 = https://github.com/Bearsampp/module-postgresql/releases/download/2026.6.2/bearsampp-postgresql-17.10-2025.6.2.7z
 17.9 = https://github.com/Bearsampp/module-postgresql/releases/download/2026.3.8/bearsampp-postgresql-17.9-2025.3.8.7z
 17.7 = https://github.com/Bearsampp/module-postgresql/releases/download/2025.11.22/bearsampp-postgresql-17.7-2025.7.2.7z
 17.5 = https://github.com/Bearsampp/module-postgresql/releases/download/2025.7.2/bearsampp-postgresql-17.5-2025.7.2.7z
@@ -7,6 +9,7 @@
 17.2.3 = https://github.com/Bearsampp/module-postgresql/releases/download/2025.2.13/bearsampp-postgresql-17.2.3-2025.2.13.7z
 17.2.1 = https://github.com/Bearsampp/module-postgresql/releases/download/2024.12.1/bearsampp-postgresql-17.2.1-2024.12.1.7z
 17.0-RC1 = https://github.com/Bearsampp/module-postgresql/releases/download/2024.9.18/bearsampp-postgresql-17.0-RC1-2024.9.18.7z
+16.14 = https://github.com/Bearsampp/module-postgresql/releases/download/2026.6.2/bearsampp-postgresql-16.14-2025.6.2.7z
 16.13 = https://github.com/Bearsampp/module-postgresql/releases/download/2026.3.8/bearsampp-postgresql-16.13-2025.3.8.7z
 16.11 = https://github.com/Bearsampp/module-postgresql/releases/download/2025.11.22/bearsampp-postgresql-16.11-2025.7.2.7z
 16.9 = https://github.com/Bearsampp/module-postgresql/releases/download/2025.7.2/bearsampp-postgresql-16.9-2025.7.2.7z
@@ -14,6 +17,7 @@
 16.4 = https://github.com/Bearsampp/module-postgresql/releases/download/2024.9.18/bearsampp-postgresql-16.4-2024.9.18.7z
 16.2 = https://github.com/Bearsampp/module-postgresql/releases/download/2024.4.16/bearsampp-postgresql-16.2-2024.4.16.7z
 16.0 = https://github.com/Bearsampp/module-postgresql/releases/download/2023.10.9/bearsampp-postgresql-16.0-2023.10.9.7z
+15.18 = https://github.com/Bearsampp/module-postgresql/releases/download/2026.6.2/bearsampp-postgresql-15.18-2025.6.2.7z
 15.17 = https://github.com/Bearsampp/module-postgresql/releases/download/2026.3.8/bearsampp-postgresql-15.17-2025.3.8.7z
 15.15 = https://github.com/Bearsampp/module-postgresql/releases/download/2025.11.22/bearsampp-postgresql-15.15-2025.7.2.7z
 15.13 = https://github.com/Bearsampp/module-postgresql/releases/download/2025.7.2/bearsampp-postgresql-15.13-2025.7.2.7z
@@ -23,7 +27,8 @@
 15.3 = https://github.com/Bearsampp/module-postgresql/releases/download/2023.7.23/bearsampp-postgresql-15.3-2023.7.23.7z
 15.2 = https://github.com/Bearsampp/module-postgresql/releases/download/2023.4.20/bearsampp-postgresql-15.2-2023.4.24.7z
 15.0 = https://github.com/Bearsampp/module-postgresql/releases/download/2022.10.28/bearsampp-postgresql-15.0-2022.10.28.7z
-14.22 = https://github.com/Bearsampp/module-postgresql/releases/download/2026.3.8/bearsampp-postgresql-14.22-2025.3.8.7z
+14.23 = https://github.com/Bearsampp/module-postgresql/releases/download/2026.6.2/bearsampp-postgresql-14.23-2025.6.2.7z
+14.22 = https://github.com/Bearsampp/module-postgresql/releases/download/2026.6.2/bearsampp-postgresql-14.22-2025.6.2.7z
 14.20 = https://github.com/Bearsampp/module-postgresql/releases/download/2025.11.22/bearsampp-postgresql-14.20-2025.7.2.7z
 14.18 = https://github.com/Bearsampp/module-postgresql/releases/download/2025.7.2/bearsampp-postgresql-14.18-2025.7.2.7z
 14.17 = https://github.com/Bearsampp/module-postgresql/releases/download/2025.2.21/bearsampp-postgresql-14.17-2025.2.21.7z


### PR DESCRIPTION
## 🤖 Automated Releases Properties Update

This PR updates the `releases.properties` file with new versions from release `2026.6.2`.

### Changes:
- Extracted .7z assets from the release
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/module-postgresql/releases/tag/2026.6.2

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs